### PR TITLE
Header frame sizes

### DIFF
--- a/widgets/headers/style.css
+++ b/widgets/headers/style.css
@@ -32,7 +32,9 @@ section[role="region"] > header:first-child h1 {
   text-overflow: ellipsis;
   display: block;
   overflow: hidden;
-  margin: 0 0 0 3rem;
+  position: absolute;
+  left: 3rem;
+  margin: 0;
   height: 100%
 }
 
@@ -62,7 +64,7 @@ section[role="region"] > header:first-child input[type=text] {
 }
 
 section[role="region"] > header:first-child form button[type="reset"] {
-  text-indent: -9999px;
+  font-size: 0px;
   overflow: hidden;
   position: absolute;
   right: 1rem;
@@ -167,7 +169,7 @@ section[role="region"] > header:first-child .icon {
   height: 3rem;
   margin: 0 -1rem;
   background: transparent no-repeat center center;
-  text-indent: -9999px;
+  font-size: 0;
   overflow: hidden;
   position: relative;
   height: 4.9rem;
@@ -211,8 +213,9 @@ section[role="region"] > header:first-child > a {
 
 section[role="region"] > header:first-child > button .icon,
 section[role="region"] > header:first-child > a .icon {
+  font-size: 0;
+  line-height: 10rem;
   overflow: visible;
-  text-indent: -9999px;
   position: static;
   margin-left: -3rem;
   height: 4.9rem;
@@ -256,7 +259,8 @@ section[role="region"] > header:after {
 section[role="region"] > header h2 {
   font-family: "Open Sans", Sans-serif;
   font-weight: 600;
-  margin: 0 3rem;
+  margin: 0;
+  padding: 0 3rem;
   font-size: 1.3rem;
   line-height: 1.8rem;
 }

--- a/widgets/headers/style.css
+++ b/widgets/headers/style.css
@@ -32,7 +32,6 @@ section[role="region"] > header:first-child h1 {
   text-overflow: ellipsis;
   display: block;
   overflow: hidden;
-  position: absolute;
   padding-left: 3rem;
   margin: 0;
   height: 100%

--- a/widgets/headers/style.css
+++ b/widgets/headers/style.css
@@ -33,7 +33,7 @@ section[role="region"] > header:first-child h1 {
   display: block;
   overflow: hidden;
   position: absolute;
-  left: 3rem;
+  padding-left: 3rem;
   margin: 0;
   height: 100%
 }

--- a/widgets/headers/style.css
+++ b/widgets/headers/style.css
@@ -214,7 +214,7 @@ section[role="region"] > header:first-child > a {
 section[role="region"] > header:first-child > button .icon,
 section[role="region"] > header:first-child > a .icon {
   font-size: 0;
-  line-height: 10rem;
+  line-height: 3rem;
   overflow: visible;
   position: static;
   margin-left: -3rem;


### PR DESCRIPTION
Reduces header frame sizes so animations on elements that contain header BB will be async.
Note: I know this breaks at minimum the drawer BB, this is just my proposal / starting point.
